### PR TITLE
Refactor and clean up

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,12 +22,11 @@
     "os-utils": "^0.0.14",
     "react": "^19.2.4",
     "react-dom": "^19.2.4",
-    "recharts": "^3.8.1",
-    "request": "^2.88.2",
-    "vitest": "^4.1.5"
+    "recharts": "^3.8.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "vitest": "^4.1.5",
     "@playwright/test": "^1.59.1",
     "@types/node": "^24.12.0",
     "@types/os-utils": "^0.0.4",

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -2,7 +2,7 @@ import { app, BaseWindow } from "electron";
 import { pollResources, } from "./resourceManager.js";
 import { createTray } from "./tray.js";
 import { createMenu } from "./menu.js";
-import { createTabBarView, createContentView } from "./view.js";
+import { createTabBarView, createContentView, getContentViews, TABBAR_HEIGHT } from "./view.js";
 import { registerProtocol, setMainWindowForDeepLink } from "./protocol.js";
 import { initIpcHandlers } from "./ipcHandlers.js";
 
@@ -12,7 +12,7 @@ app.whenReady().then(() => {
     const mainWindow = new BaseWindow({ width: 800, height: 600, frame: false });
 
     // Create tabbar view first (chrome)
-    createTabBarView(mainWindow);
+    const tabBarView = createTabBarView(mainWindow);
     // Create initial content view
     const contentView = createContentView(mainWindow);
     pollResources(contentView);
@@ -23,6 +23,15 @@ app.whenReady().then(() => {
     createTray(mainWindow);
     createMenu(mainWindow, contentView);
     handleCloseEvents(mainWindow);
+
+    // Single resize listener for all views
+    mainWindow.on('resize', () => {
+        const { width, height } = mainWindow.getContentBounds();
+        tabBarView.setBounds({ x: 0, y: 0, width, height: TABBAR_HEIGHT });
+        for (const view of getContentViews()) {
+            view.setBounds({ x: 0, y: TABBAR_HEIGHT, width, height: height - TABBAR_HEIGHT });
+        }
+    });
 });
 
 /**

--- a/src/electron/util.ts
+++ b/src/electron/util.ts
@@ -2,6 +2,8 @@ import { ipcMain, type WebContents, type WebFrameMain } from "electron";
 import { getUIPath } from "./pathResolver.js";
 import { pathToFileURL } from "url";
 
+export const DEV_SERVER_URL = "http://localhost:5123";
+
 export function isDev(): boolean {
     return process.env.NODE_ENV === "development";
 }
@@ -43,7 +45,7 @@ export function validateEventFrame(frame: WebFrameMain | null) {
         throw new Error("No frame found");
     }
     // If we are in development, check that the current frames url matches our development server url
-    if (isDev() && new URL(frame.url).host === "localhost:5123") {
+    if (isDev() && new URL(frame.url).host === new URL(DEV_SERVER_URL).host) {
         return;
     }
     // If we are not in development, check that the current frames url matches one of our built app urls

--- a/src/electron/view.ts
+++ b/src/electron/view.ts
@@ -3,7 +3,7 @@ import { getPreloadPath, getUIPath } from "./pathResolver.js";
 import { isDev } from "./util.js";
 import { createMenu } from "./menu.js";
 
-const TABBAR_HEIGHT = 44;
+export const TABBAR_HEIGHT = 44;
 const contentViews: WebContentsView[] = [];
 
 /**
@@ -25,13 +25,9 @@ export function createTabBarView(baseWindow: BaseWindow): WebContentsView {
 
     baseWindow.contentView.addChildView(view);
 
-    const updateBounds = () => {
-        const { width } = baseWindow.getContentBounds();
-        view.setBounds({ x: 0, y: 0, width, height: TABBAR_HEIGHT });
-    };
-
-    updateBounds();
-    baseWindow.on('resize', updateBounds);
+    // Set initial bounds
+    const { width } = baseWindow.getContentBounds();
+    view.setBounds({ x: 0, y: 0, width, height: TABBAR_HEIGHT });
 
     return view;
 }
@@ -56,15 +52,11 @@ export function createContentView(baseWindow: BaseWindow): WebContentsView {
     baseWindow.contentView.addChildView(view);
     contentViews.push(view);
 
+    // Set initial bounds
+    const { width, height } = baseWindow.getContentBounds();
+    view.setBounds({ x: 0, y: TABBAR_HEIGHT, width, height: height - TABBAR_HEIGHT });
+
     createMenu(baseWindow, view); // make sure we create the application menu for each content view
-
-    const updateBounds = () => {
-        const { width, height } = baseWindow.getContentBounds();
-        view.setBounds({ x: 0, y: TABBAR_HEIGHT, width, height: height - TABBAR_HEIGHT });
-    };
-
-    updateBounds();
-    baseWindow.on('resize', updateBounds);
 
     return view;
 }

--- a/src/electron/view.ts
+++ b/src/electron/view.ts
@@ -1,6 +1,6 @@
 import { BaseWindow, WebContentsView } from "electron";
 import { getPreloadPath, getUIPath } from "./pathResolver.js";
-import { isDev } from "./util.js";
+import { isDev, DEV_SERVER_URL } from "./util.js";
 import { createMenu } from "./menu.js";
 
 export const TABBAR_HEIGHT = 44;
@@ -18,7 +18,7 @@ export function createTabBarView(baseWindow: BaseWindow): WebContentsView {
     });
 
     if (isDev()) {
-        view.webContents.loadURL("http://localhost:5123/src/ui/tabbar/index.html");
+        view.webContents.loadURL(`${DEV_SERVER_URL}/src/ui/tabbar/index.html`);
     } else {
         view.webContents.loadFile(getUIPath("tabbar"));
     }
@@ -44,7 +44,7 @@ export function createContentView(baseWindow: BaseWindow): WebContentsView {
     });
 
     if (isDev()) {
-        view.webContents.loadURL("http://localhost:5123/src/ui/content/index.html");
+        view.webContents.loadURL(`${DEV_SERVER_URL}/src/ui/content/index.html`);
     } else {
         view.webContents.loadFile(getUIPath("content"));
     }


### PR DESCRIPTION
## Summary
- Replaces per-view resize listeners with a single listener in `main.ts`
- Exports `TABBAR_HEIGHT` constant from `view.ts`
- Adds missing initial bounds setting for content views

Previously, each call to `createTabBarView` and `createContentView` added a new resize listener to `baseWindow`. Now there's one listener that handles all views, automatically covering new tabs via `getContentViews()`.

## Test plan
- [ ] Verify window resizing works correctly
- [ ] Verify new tabs resize properly
- [ ] Verify closing tabs doesn't cause resize issues