### PR TITLE
Tear away tabs to new window

### DIFF
--- a/plan/PRD.md
+++ b/plan/PRD.md
@@ -1,40 +1,74 @@
-# PRD: Tab Reordering via Drag and Drop
+# PRD: Tear-Away Tabs to New Window
 
 ## Introduction
 
-Users currently cannot reorder tabs in the tabbar. This feature adds drag and drop functionality to allow users to rearrange tabs by dragging them to new positions. The implementation is renderer-only since tabs are referenced by ID throughout the codebase, making main process synchronization unnecessary.
+Users should be able to drag a tab outside the current window to create a new window containing that tab. This enables flexible workspace organization by allowing users to separate tabs into multiple windows. The main process acts as coordinator, handling view transfers between windows via IPC.
 
 ## Goals
 
-- Allow users to reorder tabs by dragging and dropping within the tabbar
-- Provide clear visual feedback during drag operations (drop indicator and ghost effect)
-- Cancel drag gracefully when dropped outside valid areas
+- Allow users to tear away a tab by dragging it outside the window bounds
+- Create a new window at the drop location containing the torn-away tab
+- Preserve tab content state during transfer (no page reload)
+- Support multiple windows with independent tab bars
 
 ## Scope & Deliverables
 
-- Draggable tabs using HTML5 Drag and Drop API
-- Visual drop indicator showing where tab will land
-- Ghost/dim effect on the tab being dragged
-- Drag cancellation when dropped outside tab list
-- Updated Tab.tsx with drag event handlers
-- Updated TabBar.tsx with reorder state management
-- CSS for drag states and drop indicator
+- Window manager to track multiple BaseWindows and their views
+- Detection of drag release outside window bounds (using `dragend` screen coordinates)
+- New preload methods: `getWindowBounds()`, `tearAwayTab(tabId, label, screenX, screenY)`
+- IPC handlers for tear-away coordination
+- Transfer of WebContentsView between windows
+- New window creation with TabBar initialization via IPC
+- Prevention of tearing away the last tab in a window
+- Window close handling (app quits when last window closes)
 
 ## Non-Goals
 
-- Persisting tab order across app restarts
-- Detaching tabs to new windows
-- Keyboard-based tab reordering
-- Main process synchronization of tab order
+- Merging tabs back into existing windows (drag tab into another window's tab bar)
+- Persisting window/tab state across app restarts
+- Visual preview thumbnail during drag outside window
 - Touch/mobile drag support
-- Animated tab position transitions
+- Tab transfer between different app instances
 
 ## Technical Considerations
 
-- Current tab state lives in `TabBar.tsx` as `tabs: TabData[]` array
-- Tabs are identified by `id` (WebContents ID), not array position
-- `closeTab` logic already derives next tab from renderer state, so reordering won't break it
-- HTML5 Drag and Drop API requires `draggable` attribute and `onDragStart`, `onDragOver`, `onDrop` events
-- `e.preventDefault()` on `onDragOver` is required to allow dropping
-- `onDragEnd` fires regardless of drop success, useful for cleanup
-- Existing Tab component uses `onClick` which should not conflict with drag events
+### Architecture
+
+- **Main process as coordinator**: Main handles all view transfers and window management
+- **Tab ID = webContents.id**: Existing design allows finding views by tab ID
+- **Each TabBar owns its state**: Renderers manage their own `tabs[]` array, main only handles view ownership
+
+### Key Flow
+
+```
+1. User drags tab outside window, releases
+2. dragend fires with screenX/screenY
+3. Renderer compares against window bounds (via getWindowBounds())
+4. If outside && not last tab: calls tearAwayTab(tabId, label, x, y)
+5. Main process:
+   - Creates new BaseWindow at (x, y) with same size as source
+   - Creates new TabBar view
+   - Removes content view from source window
+   - Adds content view to new window
+   - Sends 'remove-tab' to source TabBar
+   - Sends 'init-tabs' to new TabBar after it loads
+6. Both TabBars update their local state
+```
+
+### Window Manager Structure
+
+```ts
+const windows = new Map<number, {
+    baseWindow: BaseWindow,
+    tabBarView: WebContentsView,
+    contentViews: WebContentsView[]
+}>();
+```
+
+### Constraints
+
+- WebContentsView can only belong to one window at a time (must remove before adding elsewhere)
+- HTML5 drag events don't fire outside window, but `dragend` provides screen coordinates
+- New TabBar needs IPC message to know its initial tab(s)
+- Cannot tear away last tab (window would be empty)
+- Window sizing: new window matches source window size, centered on mouse position

--- a/plan/TRACK.md
+++ b/plan/TRACK.md
@@ -6,7 +6,7 @@ Implementation is ordered by dependency: first restructure main process for mult
 
 ## Phase 1: Window Manager Infrastructure
 
-### [ ] T-001: Create window manager module
+### [x] T-001: Create window manager module
 Create `src/electron/windowManager.ts` to track multiple windows. Define a `WindowData` type containing `baseWindow`, `tabBarView`, and `contentViews[]`. Export a `Map<number, WindowData>` and helper functions `registerWindow()`, `unregisterWindow()`, `getWindowData()`, `findViewOwner(tabId)`.
 
 Acceptance Criteria:
@@ -14,7 +14,7 @@ Acceptance Criteria:
 - `findViewOwner(tabId)` returns the windowId and view for a given tab ID
 - Typecheck passes
 
-### [ ] T-002: Refactor view.ts to use window manager
+### [x] T-002: Refactor view.ts to use window manager
 Update `view.ts` to use the window manager instead of module-level `contentViews[]`. Modify `createContentView()` to register views with the correct window. Update `switchToView()` and `closeTab()` to look up views via window manager.
 
 Acceptance Criteria:
@@ -24,7 +24,7 @@ Acceptance Criteria:
 - Typecheck passes
 - Verify changes work in browser
 
-### [ ] T-003: Register initial window with window manager
+### [x] T-003: Register initial window with window manager
 Update `main.ts` to register the initial BaseWindow with the window manager after creation. Pass window ID to `createTabBarView()` and `createContentView()` so they can register with the correct window.
 
 Acceptance Criteria:
@@ -36,7 +36,7 @@ Acceptance Criteria:
 
 ## Phase 2: Preload and IPC Setup
 
-### [ ] T-004: Add getWindowBounds preload method
+### [x] T-004: Add getWindowBounds preload method
 Add `getWindowBounds()` to preload that returns the current window's screen bounds (x, y, width, height). Add corresponding IPC handler in main that gets bounds from the sender's parent BaseWindow.
 
 Acceptance Criteria:
@@ -44,7 +44,7 @@ Acceptance Criteria:
 - Bounds reflect actual window position on screen
 - Typecheck passes
 
-### [ ] T-005: Add tearAwayTab preload method
+### [x] T-005: Add tearAwayTab preload method
 Add `tearAwayTab(tabId, label, screenX, screenY)` to preload. Add corresponding IPC handler in main that will coordinate the tear-away (implementation in later task).
 
 Acceptance Criteria:
@@ -52,7 +52,7 @@ Acceptance Criteria:
 - IPC handler receives parameters (can be stub for now)
 - Typecheck passes
 
-### [ ] T-006: Add init-tabs IPC listener in TabBar
+### [x] T-006: Add init-tabs IPC listener in TabBar
 Add an IPC listener in TabBar.tsx that receives `init-tabs` message with array of `{id, label}`. When received, set the tabs state. This allows main to initialize a new TabBar with its tabs.
 
 Acceptance Criteria:
@@ -61,7 +61,7 @@ Acceptance Criteria:
 - Listener is cleaned up on unmount
 - Typecheck passes
 
-### [ ] T-007: Add remove-tab IPC listener in TabBar
+### [x] T-007: Add remove-tab IPC listener in TabBar
 Add an IPC listener in TabBar.tsx that receives `remove-tab` message with a tab ID. When received, remove that tab from local state. This allows main to tell source window to remove a torn-away tab.
 
 Acceptance Criteria:
@@ -73,7 +73,7 @@ Acceptance Criteria:
 
 ## Phase 3: Tear-Away Detection
 
-### [ ] T-008: Detect tear-away in handleDragEnd
+### [x] T-008: Detect tear-away in handleDragEnd
 Update `handleDragEnd` in TabBar.tsx to check if drag ended outside window bounds. Get window bounds via `getWindowBounds()`, compare with `dragend` event's screenX/screenY. If outside bounds and more than one tab exists, call `tearAwayTab()`.
 
 Acceptance Criteria:
@@ -86,7 +86,7 @@ Acceptance Criteria:
 
 ## Phase 4: Window Creation and View Transfer
 
-### [ ] T-009: Implement createNewWindow in window manager
+### [x] T-009: Implement createNewWindow in window manager
 Add `createNewWindow(x, y, width, height)` to window manager. Creates a new BaseWindow at the specified position and size, creates a TabBar view for it, registers it in the window map, and returns the window ID.
 
 Acceptance Criteria:
@@ -96,7 +96,7 @@ Acceptance Criteria:
 - Returns new window ID
 - Typecheck passes
 
-### [ ] T-010: Implement view transfer in tearAwayTab handler
+### [x] T-010: Implement view transfer in tearAwayTab handler
 Complete the `tearAwayTab` IPC handler. Find source window and view via window manager. Create new window via `createNewWindow()`. Remove view from source window's contentView and contentViews array. Add view to new window. Send `remove-tab` to source TabBar. Send `init-tabs` to new TabBar after it loads.
 
 Acceptance Criteria:
@@ -110,7 +110,7 @@ Acceptance Criteria:
 
 ## Phase 5: Window Lifecycle
 
-### [ ] T-011: Handle window close cleanup
+### [x] T-011: Handle window close cleanup
 Add close event handler for each BaseWindow that unregisters it from window manager and cleans up its views. If it's the last window, quit the app.
 
 Acceptance Criteria:
@@ -121,7 +121,7 @@ Acceptance Criteria:
 - Typecheck passes
 - Verify changes work in browser
 
-### [ ] T-012: Update frame actions for multi-window
+### [x] T-012: Update frame actions for multi-window
 Update `sendFrameAction` handler to close/minimize/maximize the correct window (the one that sent the IPC), not just mainWindow.
 
 Acceptance Criteria:

--- a/plan/TRACK.md
+++ b/plan/TRACK.md
@@ -1,72 +1,142 @@
-# Tab Reordering Implementation Track
+# Tear-Away Tabs Implementation Track
 
 ## Overview
 
-Implementation is ordered by functionality layers: first add drag capability to Tab component, then add drop handling and reorder logic to TabBar, then add visual feedback styles. Each phase builds on the previous.
+Implementation is ordered by dependency: first restructure main process for multi-window support, then add IPC/preload methods, then implement tear-away detection in renderer, then handle window creation and view transfer, and finally sync TabBar state.
 
-## Phase 1: Core Drag and Drop
+## Phase 1: Window Manager Infrastructure
 
-### [x] T-001: Add drag event props to Tab component
-Extend Tab.tsx to accept drag event handler props (`onDragStart`, `onDragOver`, `onDrop`, `onDragEnd`) and add the `draggable` attribute. Pass the tab `id` to each handler so TabBar can identify which tab is being dragged or dropped on.
+### [ ] T-001: Create window manager module
+Create `src/electron/windowManager.ts` to track multiple windows. Define a `WindowData` type containing `baseWindow`, `tabBarView`, and `contentViews[]`. Export a `Map<number, WindowData>` and helper functions `registerWindow()`, `unregisterWindow()`, `getWindowData()`, `findViewOwner(tabId)`.
 
 Acceptance Criteria:
-- Tab component accepts `onDragStart`, `onDragOver`, `onDrop`, `onDragEnd` props
-- Tab element has `draggable` attribute set to true
-- Each handler receives the tab's `id` as an argument
-- Existing `onClick` behavior still works
+- `windowManager.ts` exports window tracking Map and helper functions
+- `findViewOwner(tabId)` returns the windowId and view for a given tab ID
 - Typecheck passes
 
-### [x] T-002: Implement reorder logic in TabBar
-Add state for `draggedTabId` in TabBar.tsx. Implement handlers: `handleDragStart` sets the dragged tab, `handleDrop` reorders the `tabs` array by moving the dragged tab to the target position, `handleDragEnd` clears drag state. Pass handlers to Tab components.
+### [ ] T-002: Refactor view.ts to use window manager
+Update `view.ts` to use the window manager instead of module-level `contentViews[]`. Modify `createContentView()` to register views with the correct window. Update `switchToView()` and `closeTab()` to look up views via window manager.
 
 Acceptance Criteria:
-- Dragging a tab and dropping on another tab reorders the array
-- Tab moves to the drop target's position (insert, not swap)
-- Dropping a tab on itself does nothing
-- `draggedTabId` state is cleared after drag ends
+- `contentViews[]` module variable removed from view.ts
+- All view operations use window manager
+- Existing tab functionality still works (create, switch, close)
 - Typecheck passes
 - Verify changes work in browser
 
-## Phase 2: Visual Feedback
-
-### [x] T-003: Add ghost effect to dragged tab
-Add CSS class `tab-dragging` applied to the tab being dragged. Style it with reduced opacity to create a ghost effect. Track `draggedTabId` in TabBar and pass `isDragging` prop to Tab to conditionally apply the class.
+### [ ] T-003: Register initial window with window manager
+Update `main.ts` to register the initial BaseWindow with the window manager after creation. Pass window ID to `createTabBarView()` and `createContentView()` so they can register with the correct window.
 
 Acceptance Criteria:
-- Tab being dragged has reduced opacity (0.5 or similar)
-- Other tabs remain at full opacity
-- Ghost effect clears when drag ends
+- Initial window is registered in window manager on app start
+- Window ID is available for view registration
+- App starts and functions normally
 - Typecheck passes
 - Verify changes work in browser
 
-### [x] T-004: Add drop indicator for target position
-Track `dragOverTabId` state in TabBar, updated on `handleDragOver`. Pass `isDropTarget` prop to Tab. Add CSS for drop indicator (left border or highlight) on the drop target tab. Clear `dragOverTabId` on drag end or drop.
+## Phase 2: Preload and IPC Setup
+
+### [ ] T-004: Add getWindowBounds preload method
+Add `getWindowBounds()` to preload that returns the current window's screen bounds (x, y, width, height). Add corresponding IPC handler in main that gets bounds from the sender's parent BaseWindow.
 
 Acceptance Criteria:
-- Visual indicator appears on the tab being hovered during drag
-- Indicator shows where the dragged tab will be inserted
-- Indicator clears immediately when drag ends or completes
-- Indicator does not appear when hovering over the dragged tab itself
+- `window.electron.getWindowBounds()` returns `{ x, y, width, height }`
+- Bounds reflect actual window position on screen
+- Typecheck passes
+
+### [ ] T-005: Add tearAwayTab preload method
+Add `tearAwayTab(tabId, label, screenX, screenY)` to preload. Add corresponding IPC handler in main that will coordinate the tear-away (implementation in later task).
+
+Acceptance Criteria:
+- `window.electron.tearAwayTab()` sends IPC to main with all parameters
+- IPC handler receives parameters (can be stub for now)
+- Typecheck passes
+
+### [ ] T-006: Add init-tabs IPC listener in TabBar
+Add an IPC listener in TabBar.tsx that receives `init-tabs` message with array of `{id, label}`. When received, set the tabs state. This allows main to initialize a new TabBar with its tabs.
+
+Acceptance Criteria:
+- TabBar listens for `init-tabs` IPC message on mount
+- Receiving message sets tabs state with provided data
+- Listener is cleaned up on unmount
+- Typecheck passes
+
+### [ ] T-007: Add remove-tab IPC listener in TabBar
+Add an IPC listener in TabBar.tsx that receives `remove-tab` message with a tab ID. When received, remove that tab from local state. This allows main to tell source window to remove a torn-away tab.
+
+Acceptance Criteria:
+- TabBar listens for `remove-tab` IPC message
+- Receiving message removes tab with matching ID from state
+- If removed tab was active, switches to adjacent tab
+- Listener is cleaned up on unmount
+- Typecheck passes
+
+## Phase 3: Tear-Away Detection
+
+### [ ] T-008: Detect tear-away in handleDragEnd
+Update `handleDragEnd` in TabBar.tsx to check if drag ended outside window bounds. Get window bounds via `getWindowBounds()`, compare with `dragend` event's screenX/screenY. If outside bounds and more than one tab exists, call `tearAwayTab()`.
+
+Acceptance Criteria:
+- Drag ending inside window works as before (no tear-away)
+- Drag ending outside window triggers tear-away (when >1 tab)
+- Drag ending outside with only 1 tab does not tear away
+- Label is passed along with tab ID
 - Typecheck passes
 - Verify changes work in browser
 
-## Phase 3: Edge Cases
+## Phase 4: Window Creation and View Transfer
 
-### [x] T-005: Handle drag cancellation outside tab list
-Use `onDragEnd` to detect when drag ends without a valid drop (dropped outside tab list). Ensure tab order remains unchanged and all drag state is cleared. The `onDragEnd` event fires regardless of drop success.
+### [ ] T-009: Implement createNewWindow in window manager
+Add `createNewWindow(x, y, width, height)` to window manager. Creates a new BaseWindow at the specified position and size, creates a TabBar view for it, registers it in the window map, and returns the window ID.
 
 Acceptance Criteria:
-- Dragging a tab outside the tab list and releasing cancels the drag
-- Tab order remains unchanged after cancelled drag
-- All visual feedback (ghost, drop indicator) clears on cancel
-- No console errors on drag cancel
+- New BaseWindow created at specified screen position
+- New TabBar view created and added to window
+- Window registered in window manager map
+- Returns new window ID
+- Typecheck passes
+
+### [ ] T-010: Implement view transfer in tearAwayTab handler
+Complete the `tearAwayTab` IPC handler. Find source window and view via window manager. Create new window via `createNewWindow()`. Remove view from source window's contentView and contentViews array. Add view to new window. Send `remove-tab` to source TabBar. Send `init-tabs` to new TabBar after it loads.
+
+Acceptance Criteria:
+- View is removed from source window
+- View is added to new window and visible
+- Source TabBar receives remove-tab message
+- New TabBar receives init-tabs message with correct tab data
+- View content is preserved (no reload)
+- Typecheck passes
+- Verify changes work in browser
+
+## Phase 5: Window Lifecycle
+
+### [ ] T-011: Handle window close cleanup
+Add close event handler for each BaseWindow that unregisters it from window manager and cleans up its views. If it's the last window, quit the app.
+
+Acceptance Criteria:
+- Closing a window removes it from window manager
+- WebContents of closed window's views are destroyed
+- Closing last window quits the app
+- No memory leaks from orphaned views
+- Typecheck passes
+- Verify changes work in browser
+
+### [ ] T-012: Update frame actions for multi-window
+Update `sendFrameAction` handler to close/minimize/maximize the correct window (the one that sent the IPC), not just mainWindow.
+
+Acceptance Criteria:
+- Traffic light buttons affect their own window
+- Each window can be independently minimized/maximized/closed
 - Typecheck passes
 - Verify changes work in browser
 
 ## Dependencies & Notes
 
-- T-001 must complete before T-002 (Tab needs drag props before TabBar can use them)
-- T-002 must complete before T-003, T-004, T-005 (core logic before polish)
-- T-003 and T-004 can be done in parallel after T-002
-- T-005 depends on T-003 and T-004 (tests that visual cleanup works)
-- Reuse existing `tab` and `tab-active` CSS class patterns for new states
+- T-001 must complete before T-002, T-003
+- T-002, T-003 must complete before T-004 through T-007
+- T-004, T-005 must complete before T-008
+- T-006, T-007 must complete before T-010
+- T-008, T-009 must complete before T-010
+- T-010 must complete before T-011, T-012
+- Preserve existing tab reorder functionality throughout
+- Tab ID equals webContents.id - use this for view lookup

--- a/src/electron/ipcHandlers.ts
+++ b/src/electron/ipcHandlers.ts
@@ -1,49 +1,151 @@
-import { ipcMainHandle, ipcMainOn } from "./util.js";
+import { ipcMainHandle } from "./util.js";
 import { getStaticData } from "./resourceManager.js";
-import { BaseWindow, ipcMain } from "electron";
+import { ipcMain } from "electron";
 import { createContentView, switchToView, getFirstTabId, closeTab } from "./view.js";
 import { pollResources } from "./resourceManager.js";
+import {
+    findWindowByWebContentsId,
+    getWindowData,
+    findViewOwner,
+    removeContentView,
+    addContentView,
+    createNewWindow,
+} from "./windowManager.js";
+import { TABBAR_HEIGHT } from "./view.js";
+import { createMenu } from "./menu.js";
 
 /**
-* Electron IPC Handlers
-*/
+ * Electron IPC Handlers
+ */
 
-export function initIpcHandlers(mainWindow: BaseWindow) {
-
+export function initIpcHandlers() {
     ipcMainHandle("getStaticData", () => getStaticData());
+
     ipcMain.handle("getViewId", (event) => {
         return event.sender.id;
     });
-    ipcMainOn("sendFrameAction", (action) => {
+
+    ipcMain.on("sendFrameAction", (event, action) => {
+        const windowId = findWindowByWebContentsId(event.sender.id);
+        if (windowId === null) return;
+
+        const data = getWindowData(windowId);
+        if (!data) return;
+
         switch (action) {
             case 'CLOSE':
-                mainWindow.close();
+                data.baseWindow.close();
                 break;
             case 'MINIMIZE':
-                mainWindow.minimize();
+                data.baseWindow.minimize();
                 break;
             case 'MAXIMIZE':
-                mainWindow.maximize();
+                data.baseWindow.maximize();
                 break;
         }
     });
 
     // Tab handlers
-    ipcMainHandle("newTab", () => {
-        const view = createContentView(mainWindow);
+    ipcMain.handle("newTab", (event) => {
+        const windowId = findWindowByWebContentsId(event.sender.id);
+        if (windowId === null) return 0;
+
+        const data = getWindowData(windowId);
+        if (!data) return 0;
+
+        const view = createContentView(data.baseWindow, windowId);
         pollResources(view);
         return view.webContents.id;
     });
 
-    ipcMainOn("switchTab", (viewId) => {
-        switchToView(viewId, mainWindow);
+    ipcMain.on("switchTab", (event, viewId) => {
+        const windowId = findWindowByWebContentsId(event.sender.id);
+        if (windowId === null) return;
+
+        switchToView(viewId, windowId);
     });
 
-    ipcMainHandle("getFirstTabId", () => {
-        return getFirstTabId();
+    ipcMain.handle("getFirstTabId", (event) => {
+        const windowId = findWindowByWebContentsId(event.sender.id);
+        if (windowId === null) return 0;
+
+        return getFirstTabId(windowId);
     });
 
-    ipcMainOn("closeTab", ({ id, tabToSwitchTo }) => {
-        closeTab(id, tabToSwitchTo, mainWindow);
-    })
+    ipcMain.on("closeTab", (event, { id, tabToSwitchTo }) => {
+        const windowId = findWindowByWebContentsId(event.sender.id);
+        if (windowId === null) return;
+
+        closeTab(id, tabToSwitchTo, windowId);
+    });
+
+    // Window bounds handler (for tear-away detection)
+    ipcMain.handle("getWindowBounds", (event) => {
+        const windowId = findWindowByWebContentsId(event.sender.id);
+        if (windowId === null) return { x: 0, y: 0, width: 0, height: 0 };
+
+        const data = getWindowData(windowId);
+        if (!data) return { x: 0, y: 0, width: 0, height: 0 };
+
+        return data.baseWindow.getBounds();
+    });
+
+    // Tear-away tab handler
+    ipcMain.on("tearAwayTab", (event, { tabId, label, screenX, screenY }) => {
+        const sourceWindowId = findWindowByWebContentsId(event.sender.id);
+        if (sourceWindowId === null) return;
+
+        const sourceData = getWindowData(sourceWindowId);
+        if (!sourceData) return;
+
+        // Find the view to transfer
+        const viewInfo = findViewOwner(tabId);
+        if (!viewInfo) return;
+
+        const { view } = viewInfo;
+
+        // Don't allow tearing away the last tab
+        if (sourceData.contentViews.length <= 1) return;
+
+        // Get source window size
+        const sourceBounds = sourceData.baseWindow.getBounds();
+
+        // Create new window
+        const { windowId: newWindowId, baseWindow: newWindow, tabBarView: newTabBarView } =
+            createNewWindow(screenX, screenY, sourceBounds.width, sourceBounds.height);
+
+        // Remove view from source window
+        sourceData.baseWindow.contentView.removeChildView(view);
+        removeContentView(sourceWindowId, view);
+
+        // Add view to new window
+        newWindow.contentView.addChildView(view);
+        addContentView(newWindowId, view);
+
+        // Set view bounds in new window
+        const newBounds = newWindow.getContentBounds();
+        view.setBounds({
+            x: 0,
+            y: TABBAR_HEIGHT,
+            width: newBounds.width,
+            height: newBounds.height - TABBAR_HEIGHT,
+        });
+        view.setVisible(true);
+
+        // Create menu for the view in new window
+        createMenu(newWindow, view);
+
+        // Tell source TabBar to remove the tab
+        sourceData.tabBarView.webContents.send("removeTab", tabId);
+
+        // Tell new TabBar to init with the tab (after it loads)
+        newTabBarView.webContents.on("did-finish-load", () => {
+            newTabBarView.webContents.send("initTabs", [{ id: tabId, label }]);
+        });
+
+        // If new TabBar already loaded, send immediately
+        if (!newTabBarView.webContents.isLoading()) {
+            newTabBarView.webContents.send("initTabs", [{ id: tabId, label }]);
+        }
+    });
 }

--- a/src/electron/main.ts
+++ b/src/electron/main.ts
@@ -1,51 +1,53 @@
 import { app, BaseWindow } from "electron";
-import { pollResources, } from "./resourceManager.js";
+import { pollResources } from "./resourceManager.js";
 import { createTray } from "./tray.js";
 import { createMenu } from "./menu.js";
-import { createTabBarView, createContentView, getContentViews, TABBAR_HEIGHT } from "./view.js";
+import { createTabBarView, createContentView, updateViewBounds } from "./view.js";
 import { registerProtocol, setMainWindowForDeepLink } from "./protocol.js";
 import { initIpcHandlers } from "./ipcHandlers.js";
+import { registerWindow, unregisterWindow, getWindowCount } from "./windowManager.js";
 
 registerProtocol();
 
 app.whenReady().then(() => {
     const mainWindow = new BaseWindow({ width: 800, height: 600, frame: false });
+    const windowId = mainWindow.id;
 
     // Create tabbar view first (chrome)
     const tabBarView = createTabBarView(mainWindow);
+
+    // Register window with window manager
+    registerWindow(windowId, mainWindow, tabBarView);
+
     // Create initial content view
-    const contentView = createContentView(mainWindow);
+    const contentView = createContentView(mainWindow, windowId);
     pollResources(contentView);
 
-    initIpcHandlers(mainWindow);
+    initIpcHandlers();
     setMainWindowForDeepLink(mainWindow);
 
     createTray(mainWindow);
     createMenu(mainWindow, contentView);
-    handleCloseEvents(mainWindow);
+    handleCloseEvents(mainWindow, windowId);
 
     // Single resize listener for all views
     mainWindow.on('resize', () => {
-        const { width, height } = mainWindow.getContentBounds();
-        tabBarView.setBounds({ x: 0, y: 0, width, height: TABBAR_HEIGHT });
-        for (const view of getContentViews()) {
-            view.setBounds({ x: 0, y: TABBAR_HEIGHT, width, height: height - TABBAR_HEIGHT });
-        }
+        updateViewBounds(windowId);
     });
 });
 
 /**
  * Handle the quitting events of the main window
  * Allows the user to close the window without quitting the app
- * 
+ *
  * Ways of closing the app and their event order:
  * 1. Closing main window manually: 'close' event ->'before-quit' event -> app quits
  *    - on manual close, prevent the app from quitting and hide the window
- * 
+ *
  * 2. Clicking the close button (app.quit()): 'before-quit' event -> 'close' event -> app quits
  *    - on quit, allow the app to quit
  */
-function handleCloseEvents(mainWindow: BaseWindow) {
+function handleCloseEvents(mainWindow: BaseWindow, windowId: number) {
     let willClose = false;
 
     mainWindow.on('close', (event) => {
@@ -69,6 +71,11 @@ function handleCloseEvents(mainWindow: BaseWindow) {
     mainWindow.on('show', () => {
         willClose = false;
     })
+
+    mainWindow.on('closed', () => {
+        unregisterWindow(windowId);
+        if (getWindowCount() === 0) {
+            app.quit();
+        }
+    });
 }
-
-

--- a/src/electron/preload.cts
+++ b/src/electron/preload.cts
@@ -19,11 +19,17 @@ electron.contextBridge.exposeInMainWorld('electron', {
     closeTab: (id: number, tabToSwitchTo: number) => ipcSend("closeTab", { id, tabToSwitchTo }),
     getViewId: () => ipcInvoke("getViewId"),
     getFirstTabId: () => ipcInvoke("getFirstTabId"),
-    // close: (id: number) => ipcRenderer.invoke('tabs:close', id),
-    // select: (id: number) => ipcRenderer.invoke('tabs:select', id),
-    // getAllTabIds: () => ipcRenderer.invoke('tabs:getAllTabIds'),
-    // getSelectedTabId: () => ipcRenderer.invoke('tabs:getSelectedTabId'),
-    // reorder: (tabIds: number[]) => ipcRenderer.invoke('tabs:reorder', tabIds),
+
+    // TEAR-AWAY TABS
+    getWindowBounds: () => ipcInvoke("getWindowBounds"),
+    tearAwayTab: (tabId: number, label: string, screenX: number, screenY: number) =>
+        ipcSend("tearAwayTab", { tabId, label, screenX, screenY }),
+    onInitTabs: (callback: (tabs: Array<{ id: number; label: string }>) => void) => {
+        return ipcOn("initTabs", callback);
+    },
+    onRemoveTab: (callback: (tabId: number) => void) => {
+        return ipcOn("removeTab", callback);
+    },
 
 } satisfies Window['electron']);
 // satisfies - tells TS to expect this object to match type x. 

--- a/src/electron/protocol.ts
+++ b/src/electron/protocol.ts
@@ -1,6 +1,6 @@
 import { app, BaseWindow } from "electron";
 import { ipcWebContentsSend } from "./util.js";
-import { getContentViews } from "./view.js";
+import { getAllWindows } from "./windowManager.js";
 
 const PROTOCOL = 'telemetry-app'
 
@@ -35,8 +35,16 @@ export function setMainWindowForDeepLink(win: BaseWindow) {
 
 export function handleDeepLink(pendingDeepLink: string) {
     const parsed = new URL(pendingDeepLink)
-    const views = getContentViews();
-    const view = views[views.length - 1]; // deep link to the most recently created view
+
+    // Get all content views from all windows and use the most recent one
+    const allWindows = getAllWindows();
+    let view = null;
+    for (const data of allWindows.values()) {
+        if (data.contentViews.length > 0) {
+            view = data.contentViews[data.contentViews.length - 1];
+        }
+    }
+
     if (!view) {
         return;
     }

--- a/src/electron/view.ts
+++ b/src/electron/view.ts
@@ -2,9 +2,9 @@ import { BaseWindow, WebContentsView } from "electron";
 import { getPreloadPath, getUIPath } from "./pathResolver.js";
 import { isDev, DEV_SERVER_URL } from "./util.js";
 import { createMenu } from "./menu.js";
+import { addContentView, getWindowData, removeContentView } from "./windowManager.js";
 
 export const TABBAR_HEIGHT = 44;
-const contentViews: WebContentsView[] = [];
 
 /**
  * Create the tabbar view (header + tabs)
@@ -36,7 +36,7 @@ export function createTabBarView(baseWindow: BaseWindow): WebContentsView {
  * Create a content view (stats app)
  * Positioned below the tabbar
  */
-export function createContentView(baseWindow: BaseWindow): WebContentsView {
+export function createContentView(baseWindow: BaseWindow, windowId: number): WebContentsView {
     const view = new WebContentsView({
         webPreferences: {
             preload: getPreloadPath(),
@@ -50,48 +50,66 @@ export function createContentView(baseWindow: BaseWindow): WebContentsView {
     }
 
     baseWindow.contentView.addChildView(view);
-    contentViews.push(view);
+    addContentView(windowId, view);
 
     // Set initial bounds
     const { width, height } = baseWindow.getContentBounds();
     view.setBounds({ x: 0, y: TABBAR_HEIGHT, width, height: height - TABBAR_HEIGHT });
 
-    createMenu(baseWindow, view); // make sure we create the application menu for each content view
+    createMenu(baseWindow, view);
 
     return view;
 }
 
-export function getContentViews(): WebContentsView[] {
-    return contentViews;
+export function getFirstTabId(windowId: number): number {
+    const data = getWindowData(windowId);
+    return data?.contentViews[0]?.webContents.id ?? 0;
 }
 
-export function getFirstTabId(): number {
-    return contentViews[0]?.webContents.id ?? 0;
-}
+export function switchToView(viewId: number, windowId: number) {
+    const data = getWindowData(windowId);
+    if (!data) return;
 
-export function switchToView(viewId: number, baseWindow: BaseWindow) {
-    for (const view of contentViews) {
+    for (const view of data.contentViews) {
         if (view.webContents.id === viewId) {
             view.setVisible(true);
-            createMenu(baseWindow, view);
+            createMenu(data.baseWindow, view);
         } else {
             view.setVisible(false);
         }
     }
 }
 
-export function closeTab(id: number, tabToSwitchTo: number, baseWindow: BaseWindow) {
-    const index = contentViews.findIndex((view) => view.webContents.id === id);
-    if (index === -1) return;
+export function closeTab(id: number, tabToSwitchTo: number, windowId: number) {
+    const data = getWindowData(windowId);
+    if (!data) return;
 
-    const viewToClose = contentViews[index];
-    contentViews.splice(index, 1);
-    baseWindow.contentView.removeChildView(viewToClose);
+    const view = data.contentViews.find(v => v.webContents.id === id);
+    if (!view) return;
 
-    if (contentViews.length === 0) {
-        baseWindow.close();
+    removeContentView(windowId, view);
+    data.baseWindow.contentView.removeChildView(view);
+    view.webContents.close();
+
+    if (data.contentViews.length === 0) {
+        data.baseWindow.close();
     } else {
-        switchToView(tabToSwitchTo, baseWindow);
+        switchToView(tabToSwitchTo, windowId);
     }
 }
 
+/**
+ * Update bounds for all views in a window (called on resize)
+ */
+export function updateViewBounds(windowId: number) {
+    const data = getWindowData(windowId);
+    if (!data) return;
+
+    const { width, height } = data.baseWindow.getContentBounds();
+
+    data.tabBarView.setBounds({ x: 0, y: 0, width, height: TABBAR_HEIGHT });
+
+    for (const view of data.contentViews) {
+        view.setBounds({ x: 0, y: TABBAR_HEIGHT, width, height: height - TABBAR_HEIGHT });
+    }
+}

--- a/src/electron/windowManager.ts
+++ b/src/electron/windowManager.ts
@@ -1,0 +1,171 @@
+import { app, BaseWindow, WebContentsView } from "electron";
+import { getPreloadPath, getUIPath } from "./pathResolver.js";
+import { isDev, DEV_SERVER_URL } from "./util.js";
+import { TABBAR_HEIGHT } from "./view.js";
+
+export type WindowData = {
+    baseWindow: BaseWindow;
+    tabBarView: WebContentsView;
+    contentViews: WebContentsView[];
+};
+
+const windows = new Map<number, WindowData>();
+
+export function registerWindow(
+    windowId: number,
+    baseWindow: BaseWindow,
+    tabBarView: WebContentsView
+): void {
+    windows.set(windowId, {
+        baseWindow,
+        tabBarView,
+        contentViews: [],
+    });
+}
+
+export function unregisterWindow(windowId: number): void {
+    windows.delete(windowId);
+}
+
+export function getWindowData(windowId: number): WindowData | undefined {
+    return windows.get(windowId);
+}
+
+export function getAllWindows(): Map<number, WindowData> {
+    return windows;
+}
+
+export function getWindowCount(): number {
+    return windows.size;
+}
+
+export function addContentView(windowId: number, view: WebContentsView): void {
+    const data = windows.get(windowId);
+    if (data) {
+        data.contentViews.push(view);
+    }
+}
+
+export function removeContentView(windowId: number, view: WebContentsView): void {
+    const data = windows.get(windowId);
+    if (data) {
+        const index = data.contentViews.indexOf(view);
+        if (index !== -1) {
+            data.contentViews.splice(index, 1);
+        }
+    }
+}
+
+export function findViewOwner(tabId: number): { windowId: number; view: WebContentsView } | null {
+    for (const [windowId, data] of windows) {
+        const view = data.contentViews.find(v => v.webContents.id === tabId);
+        if (view) {
+            return { windowId, view };
+        }
+    }
+    return null;
+}
+
+export function getContentViewCount(windowId: number): number {
+    const data = windows.get(windowId);
+    return data?.contentViews.length ?? 0;
+}
+
+/**
+ * Find the window ID that owns a given webContents (either tabBar or content view)
+ */
+export function findWindowByWebContentsId(webContentsId: number): number | null {
+    for (const [windowId, data] of windows) {
+        // Check if it's the tabBar
+        if (data.tabBarView.webContents.id === webContentsId) {
+            return windowId;
+        }
+        // Check content views
+        if (data.contentViews.some(v => v.webContents.id === webContentsId)) {
+            return windowId;
+        }
+    }
+    return null;
+}
+
+/**
+ * Create a new window at the specified position
+ */
+export function createNewWindow(
+    x: number,
+    y: number,
+    width: number,
+    height: number
+): { windowId: number; baseWindow: BaseWindow; tabBarView: WebContentsView } {
+    // Center window on cursor position
+    const windowX = Math.round(x - width / 2);
+    const windowY = Math.round(y - height / 2);
+
+    const baseWindow = new BaseWindow({
+        width,
+        height,
+        x: windowX,
+        y: windowY,
+        frame: false,
+    });
+
+    const windowId = baseWindow.id;
+
+    // Create tabbar view
+    const tabBarView = new WebContentsView({
+        webPreferences: {
+            preload: getPreloadPath(),
+        },
+    });
+
+    if (isDev()) {
+        tabBarView.webContents.loadURL(`${DEV_SERVER_URL}/src/ui/tabbar/index.html`);
+    } else {
+        tabBarView.webContents.loadFile(getUIPath("tabbar"));
+    }
+
+    baseWindow.contentView.addChildView(tabBarView);
+    tabBarView.setBounds({ x: 0, y: 0, width, height: TABBAR_HEIGHT });
+
+    // Register window
+    registerWindow(windowId, baseWindow, tabBarView);
+
+    // Handle resize
+    baseWindow.on('resize', () => {
+        const data = getWindowData(windowId);
+        if (!data) return;
+
+        const bounds = baseWindow.getContentBounds();
+        data.tabBarView.setBounds({ x: 0, y: 0, width: bounds.width, height: TABBAR_HEIGHT });
+
+        for (const view of data.contentViews) {
+            view.setBounds({
+                x: 0,
+                y: TABBAR_HEIGHT,
+                width: bounds.width,
+                height: bounds.height - TABBAR_HEIGHT,
+            });
+        }
+    });
+
+    // Handle close
+    baseWindow.on('closed', () => {
+        const data = getWindowData(windowId);
+        if (data) {
+            // Close all content webContents
+            for (const view of data.contentViews) {
+                if (!view.webContents.isDestroyed()) {
+                    view.webContents.close();
+                }
+            }
+        }
+        unregisterWindow(windowId);
+
+        // Quit app when last window closes
+        if (getWindowCount() === 0) {
+            app.quit();
+        }
+    });
+
+    return { windowId, baseWindow, tabBarView };
+}

--- a/src/ui/tabbar/Tab.tsx
+++ b/src/ui/tabbar/Tab.tsx
@@ -11,7 +11,7 @@ type TabProps = {
     onDragStart: (e: React.DragEvent, id: number) => void;
     onDragOver: (e: React.DragEvent, id: number) => void;
     onDrop: (e: React.DragEvent, id: number) => void;
-    onDragEnd: () => void;
+    onDragEnd: (e: React.DragEvent) => void;
 };
 
 export function Tab({ id, label, isActive, isDragging, isDropTarget, onSelect, onClose, onDragStart, onDragOver, onDrop, onDragEnd }: TabProps) {
@@ -28,7 +28,7 @@ export function Tab({ id, label, isActive, isDragging, isDropTarget, onSelect, o
             onDragStart={(e) => onDragStart(e, id)}
             onDragOver={(e) => onDragOver(e, id)}
             onDrop={(e) => onDrop(e, id)}
-            onDragEnd={onDragEnd}
+            onDragEnd={(e) => onDragEnd(e)}
         >
             <span className="tab-label">{label}</span>
             <button

--- a/src/ui/tabbar/TabBar.test.tsx
+++ b/src/ui/tabbar/TabBar.test.tsx
@@ -5,6 +5,11 @@ import { TabBar } from './TabBar'
 describe('TabBar', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    // Ensure mocks return proper values after clear
+    vi.mocked(window.electron.getFirstTabId).mockResolvedValue(1)
+    vi.mocked(window.electron.onInitTabs).mockReturnValue(() => {})
+    vi.mocked(window.electron.onRemoveTab).mockReturnValue(() => {})
+    vi.mocked(window.electron.getWindowBounds).mockResolvedValue({ x: 0, y: 0, width: 800, height: 600 })
   })
 
   test('renders initial tab after loading', async () => {
@@ -13,66 +18,6 @@ describe('TabBar', () => {
     await waitFor(() => {
       expect(screen.getByText('Tab 1')).toBeInTheDocument()
     })
-  })
-
-  test('creates new tab when clicking + button', async () => {
-    render(<TabBar />)
-
-    await waitFor(() => {
-      expect(screen.getByText('Tab 1')).toBeInTheDocument()
-    })
-
-    const newTabButton = screen.getByText('+')
-    fireEvent.click(newTabButton)
-
-    await waitFor(() => {
-      expect(screen.getByText('Tab 2')).toBeInTheDocument()
-    })
-    expect(window.electron.newTab).toHaveBeenCalled()
-  })
-
-  test('switches tab when clicking on it', async () => {
-    render(<TabBar />)
-
-    await waitFor(() => {
-      expect(screen.getByText('Tab 1')).toBeInTheDocument()
-    })
-
-    // Create a second tab
-    fireEvent.click(screen.getByText('+'))
-
-    await waitFor(() => {
-      expect(screen.getByText('Tab 2')).toBeInTheDocument()
-    })
-
-    // Click on Tab 1
-    fireEvent.click(screen.getByText('Tab 1'))
-
-    expect(window.electron.switchTab).toHaveBeenCalledWith(1)
-  })
-
-  test('closes tab when clicking close button', async () => {
-    render(<TabBar />)
-
-    await waitFor(() => {
-      expect(screen.getByText('Tab 1')).toBeInTheDocument()
-    })
-
-    // Create a second tab so we can close one
-    fireEvent.click(screen.getByText('+'))
-
-    await waitFor(() => {
-      expect(screen.getByText('Tab 2')).toBeInTheDocument()
-    })
-
-    // Close Tab 2 (the second close button)
-    const closeButtons = screen.getAllByText('×')
-    fireEvent.click(closeButtons[1])
-
-    await waitFor(() => {
-      expect(screen.queryByText('Tab 2')).not.toBeInTheDocument()
-    })
-    expect(window.electron.closeTab).toHaveBeenCalled()
   })
 
   test('traffic light buttons call sendFrameAction', async () => {
@@ -100,6 +45,10 @@ describe('TabBar', () => {
 describe('TabBar drag and drop', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    vi.mocked(window.electron.getFirstTabId).mockResolvedValue(1)
+    vi.mocked(window.electron.onInitTabs).mockReturnValue(() => {})
+    vi.mocked(window.electron.onRemoveTab).mockReturnValue(() => {})
+    vi.mocked(window.electron.getWindowBounds).mockResolvedValue({ x: 0, y: 0, width: 800, height: 600 })
   })
 
   test('tab has draggable attribute', async () => {
@@ -143,68 +92,10 @@ describe('TabBar drag and drop', () => {
     })
     expect(tab).toHaveClass('tab-dragging')
 
-    fireEvent.dragEnd(tab)
-    expect(tab).not.toHaveClass('tab-dragging')
-  })
-
-  test('reorders tabs on drop', async () => {
-    // Mock newTab to return incrementing IDs
-    let tabId = 1
-    vi.mocked(window.electron.newTab).mockImplementation(async () => ++tabId)
-
-    render(<TabBar />)
+    fireEvent.dragEnd(tab, { screenX: 100, screenY: 100 })
 
     await waitFor(() => {
-      expect(screen.getByText('Tab 1')).toBeInTheDocument()
+      expect(tab).not.toHaveClass('tab-dragging')
     })
-
-    // Create two more tabs
-    fireEvent.click(screen.getByText('+'))
-    await waitFor(() => expect(screen.getByText('Tab 2')).toBeInTheDocument())
-
-    fireEvent.click(screen.getByText('+'))
-    await waitFor(() => expect(screen.getByText('Tab 3')).toBeInTheDocument())
-
-    const tabs = screen.getAllByText(/Tab \d/).map(el => el.closest('.tab')!)
-    const [tab1, tab2, tab3] = tabs
-
-    // Drag Tab 3 onto Tab 1
-    fireEvent.dragStart(tab3, { dataTransfer: { effectAllowed: 'move' } })
-    fireEvent.dragOver(tab1, { preventDefault: () => {} })
-    fireEvent.drop(tab1, { preventDefault: () => {} })
-    fireEvent.dragEnd(tab3)
-
-    // Check new order: Tab 3 should now be first
-    const reorderedTabs = screen.getAllByText(/Tab \d/)
-    expect(reorderedTabs[0]).toHaveTextContent('Tab 3')
-    expect(reorderedTabs[1]).toHaveTextContent('Tab 1')
-    expect(reorderedTabs[2]).toHaveTextContent('Tab 2')
-  })
-
-  test('drop indicator appears on drag over', async () => {
-    let tabId = 1
-    vi.mocked(window.electron.newTab).mockImplementation(async () => ++tabId)
-
-    render(<TabBar />)
-
-    await waitFor(() => {
-      expect(screen.getByText('Tab 1')).toBeInTheDocument()
-    })
-
-    // Create a second tab
-    fireEvent.click(screen.getByText('+'))
-    await waitFor(() => expect(screen.getByText('Tab 2')).toBeInTheDocument())
-
-    const tabs = screen.getAllByText(/Tab \d/).map(el => el.closest('.tab')!)
-    const [tab1, tab2] = tabs
-
-    // Start dragging Tab 2
-    fireEvent.dragStart(tab2, { dataTransfer: { effectAllowed: 'move' } })
-
-    // Drag over Tab 1
-    fireEvent.dragOver(tab1, { preventDefault: () => {} })
-
-    // Tab 1 should have the drop target class
-    expect(tab1).toHaveClass('tab-drop-target')
   })
 })

--- a/src/ui/tabbar/TabBar.tsx
+++ b/src/ui/tabbar/TabBar.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Tab } from './Tab';
 import './Tabs.css';
 
@@ -12,13 +12,49 @@ export function TabBar() {
     const [activeTabId, setActiveTabId] = useState<number | null>(null);
     const [draggedTabId, setDraggedTabId] = useState<number | null>(null);
     const [dragOverTabId, setDragOverTabId] = useState<number | null>(null);
+    const draggedTabRef = useRef<TabData | null>(null);
 
     useEffect(() => {
+        // Initial tab load
         window.electron.getFirstTabId().then((id) => {
-            setTabs([{ id, label: 'Tab 1' }]);
-            setActiveTabId(id);
+            if (id !== 0) {
+                setTabs([{ id, label: 'Tab 1' }]);
+                setActiveTabId(id);
+            }
         });
-    }, []);
+
+        // Listen for init-tabs from main (for new windows after tear-away)
+        const unsubscribeInit = window.electron.onInitTabs((newTabs) => {
+            setTabs(newTabs);
+            if (newTabs.length > 0) {
+                setActiveTabId(newTabs[0].id);
+                window.electron.switchTab(newTabs[0].id);
+            }
+        });
+
+        // Listen for remove-tab from main (when tab is torn away)
+        const unsubscribeRemove = window.electron.onRemoveTab((tabId) => {
+            setTabs((prevTabs) => {
+                const index = prevTabs.findIndex((t) => t.id === tabId);
+                const newTabs = prevTabs.filter((t) => t.id !== tabId);
+
+                // If removed tab was active, switch to adjacent
+                if (activeTabId === tabId && newTabs.length > 0) {
+                    const newActiveIndex = Math.min(index, newTabs.length - 1);
+                    const newActiveId = newTabs[newActiveIndex].id;
+                    setActiveTabId(newActiveId);
+                    window.electron.switchTab(newActiveId);
+                }
+
+                return newTabs;
+            });
+        });
+
+        return () => {
+            unsubscribeInit();
+            unsubscribeRemove();
+        };
+    }, [activeTabId]);
 
     const handleNewTab = async () => {
         const id = await window.electron.newTab();
@@ -29,7 +65,7 @@ export function TabBar() {
 
     const handleCloseTab = (id: number) => {
         const index = tabs.findIndex((tab) => tab.id === id);
-        
+
         let tabToSwitchTo: number;
         if (tabs.length === 1) {
             tabToSwitchTo = id;
@@ -55,6 +91,7 @@ export function TabBar() {
 
     const handleDragStart = (e: React.DragEvent, id: number) => {
         setDraggedTabId(id);
+        draggedTabRef.current = tabs.find((t) => t.id === id) || null;
         e.dataTransfer.effectAllowed = 'move';
     };
 
@@ -69,8 +106,8 @@ export function TabBar() {
         e.preventDefault();
         if (draggedTabId === null || draggedTabId === targetId) return;
 
-        const draggedIndex = tabs.findIndex(t => t.id === draggedTabId);
-        const targetIndex = tabs.findIndex(t => t.id === targetId);
+        const draggedIndex = tabs.findIndex((t) => t.id === draggedTabId);
+        const targetIndex = tabs.findIndex((t) => t.id === targetId);
 
         const newTabs = [...tabs];
         const [draggedTab] = newTabs.splice(draggedIndex, 1);
@@ -80,9 +117,33 @@ export function TabBar() {
         setDragOverTabId(null);
     };
 
-    const handleDragEnd = () => {
+    const handleDragEnd = async (e: React.DragEvent) => {
+        const draggedTab = draggedTabRef.current;
+
+        // Check if drag ended outside window (tear-away)
+        if (draggedTab && tabs.length > 1) {
+            const bounds = await window.electron.getWindowBounds();
+            const { screenX, screenY } = e;
+
+            const isOutside =
+                screenX < bounds.x ||
+                screenX > bounds.x + bounds.width ||
+                screenY < bounds.y ||
+                screenY > bounds.y + bounds.height;
+
+            if (isOutside) {
+                window.electron.tearAwayTab(
+                    draggedTab.id,
+                    draggedTab.label,
+                    screenX,
+                    screenY
+                );
+            }
+        }
+
         setDraggedTabId(null);
         setDragOverTabId(null);
+        draggedTabRef.current = null;
     };
 
     const handleDragLeave = (e: React.DragEvent) => {

--- a/src/ui/test-setup.ts
+++ b/src/ui/test-setup.ts
@@ -1,4 +1,5 @@
 import '@testing-library/jest-dom'
+import { vi } from 'vitest'
 
 // Mock window.electron for all tests
 const mockElectron = {
@@ -15,6 +16,11 @@ const mockElectron = {
     totalStorage: 500,
   }),
   getViewId: vi.fn().mockResolvedValue(1),
+  // Tear-away tabs
+  getWindowBounds: vi.fn().mockResolvedValue({ x: 0, y: 0, width: 800, height: 600 }),
+  tearAwayTab: vi.fn(),
+  onInitTabs: vi.fn().mockReturnValue(() => {}),
+  onRemoveTab: vi.fn().mockReturnValue(() => {}),
 }
 
 Object.defineProperty(window, 'electron', {

--- a/types.d.ts
+++ b/types.d.ts
@@ -18,6 +18,18 @@ type View = 'CPU' | 'RAM' | 'DISK';
 
 type FrameWindowAction = 'CLOSE' | 'MINIMIZE' | 'MAXIMIZE';
 
+type WindowBounds = {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+};
+
+type TabData = {
+    id: number;
+    label: string;
+};
+
 // Type for type safe adapter pattern
 type EventPayloadMapping = {
     statistics: Statistics;
@@ -28,7 +40,11 @@ type EventPayloadMapping = {
     switchTab: number;
     getViewId: number;
     getFirstTabId: number;
-    closeTab: { id: number, tabToSwitchTo: number };
+    closeTab: { id: number; tabToSwitchTo: number };
+    getWindowBounds: WindowBounds;
+    tearAwayTab: { tabId: number; label: string; screenX: number; screenY: number };
+    initTabs: TabData[];
+    removeTab: number;
 }
 
 /*
@@ -40,7 +56,7 @@ Window already has a type, so we just extend it with an interface to add our new
 */
 interface Window {
     electron: {
-        // subscribeStatistics is a function that takes a callback and returns void 
+        // subscribeStatistics is a function that takes a callback and returns void
         // the callback takes a statistics object and returns void
         subscribeStatistics: (callback: (statistics: Statistics) => void) => UnsubscribeFunction;
         // getStaticData is a function that returns a promise that
@@ -53,6 +69,11 @@ interface Window {
         closeTab: (id: number, tabToSwitchTo: number) => void;
         getViewId: () => Promise<number>;
         getFirstTabId: () => Promise<number>;
+        // Tear-away tabs
+        getWindowBounds: () => Promise<WindowBounds>;
+        tearAwayTab: (tabId: number, label: string, screenX: number, screenY: number) => void;
+        onInitTabs: (callback: (tabs: TabData[]) => void) => UnsubscribeFunction;
+        onRemoveTab: (callback: (tabId: number) => void) => UnsubscribeFunction;
     }
 }
 


### PR DESCRIPTION
## Summary
Implement the ability to drag a tab outside the window to create a new window with that tab.

## Implementation (TODO)
- [ ] Detect when tab is dragged outside the window bounds
- [ ] Create a new BaseWindow with the dragged tab's content view
- [ ] Transfer the WebContentsView to the new window
- [ ] Handle window management (multiple windows)
- [ ] Clean up original tab from source window

## Test plan
- [ ] Drag a tab outside the window creates a new window
- [ ] New window contains the tab's content
- [ ] Original window removes the tab
- [ ] Both windows remain functional