### PR TITLE
feat: add CSS design tokens and migrate hardcoded colors (Phase 1/4)

### DIFF
--- a/src/ui/content/App.css
+++ b/src/ui/content/App.css
@@ -1,43 +1,42 @@
 .view-id {
   text-align: center;
-  padding: 0.5rem;
-  color: #888;
+  padding: var(--space-xs);
+  color: var(--color-text-muted);
   font-size: 0.875rem;
 }
 
 .main {
   display: grid;
   grid-template-columns: 16rem auto;
-  gap: 1rem;
+  gap: var(--space-md);
   align-items: center;
-  margin: 1rem;
   max-width: 900px;
   margin: auto;
-  margin-top: 1rem;
+  margin-top: var(--space-md);
 }
 
 .mainGrid {
   height: 10rem;
-  padding: 0.5rem;
+  padding: var(--space-xs);
 }
 
 .selectOption {
   display: block;
-  padding: 0.5rem;
+  padding: var(--space-xs);
   width: 100%;
-  background-color: #2c2c2c;
-  margin: 0.5rem 0;
-  border-radius: 0.5rem;
+  background-color: var(--color-surface);
+  margin: var(--space-xs) 0;
+  border-radius: var(--radius-md);
   cursor: pointer;
 }
 
 .selectOption:hover {
-  background-color: #333;
+  background-color: var(--color-surface-hover);
 }
 
 .selectOptionTitle {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-xs);
 }
 
 .selectOptionTitle :first-child {

--- a/src/ui/index.css
+++ b/src/ui/index.css
@@ -1,12 +1,37 @@
 :root {
+  /* Background layers */
+  --color-bg: #242424;
+  --color-surface: #2c2c2c;
+  --color-surface-hover: #333333;
+
+  /* Text */
+  --color-text-primary: rgba(255, 255, 255, 0.87);
+  --color-text-muted: #888888;
+
+  /* Per-metric accent colors (kept in sync with Chart.tsx COLOR_MAP) */
+  --color-cpu-stroke: #5dd4ee;
+  --color-cpu-fill: #0a4d5c;
+  --color-ram-stroke: #e99311;
+  --color-ram-fill: #5f3c07;
+  --color-disk-stroke: #1acf4d;
+  --color-disk-fill: #0b5b22;
+
+  /* Spacing */
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+
+  /* Border radius */
+  --radius-md: 0.5rem;
+
   font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
   font-size: 16px;
   line-height: 24px;
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: var(--color-text-primary);
+  background-color: var(--color-bg);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
## Summary

Establishes a CSS custom properties layer as the design foundation for the dashboard revamp. All hardcoded hex values in `App.css` and `index.css` are replaced with named tokens, making the palette consistent and easy to evolve in subsequent phases.

## Changes

- `src/ui/index.css`: Define `:root` tokens for background layers (`--color-bg`, `--color-surface`, `--color-surface-hover`), text levels (`--color-text-primary`, `--color-text-muted`), per-metric accent colors (`--color-cpu-*`, `--color-ram-*`, `--color-disk-*`), spacing, and border radius. Migrate `color` and `background-color` to use variables.
- `src/ui/content/App.css`: Replace all hardcoded hex values and magic numbers with `var(--...)` references to the new token set.

## Test Plan

- [ ] App renders visually identically to before (no color regressions)
- [ ] No hardcoded hex values remain in `App.css` or `index.css`
- [ ] Typecheck passes (pre-existing TS errors in test files are unrelated to this change)