### PR TITLE
feat: redesign metric selector cards with live usage and active state (Phase 2/4)

### DIFF
--- a/src/ui/content/App.css
+++ b/src/ui/content/App.css
@@ -1,43 +1,42 @@
 .view-id {
   text-align: center;
-  padding: 0.5rem;
-  color: #888;
+  padding: var(--space-xs);
+  color: var(--color-text-muted);
   font-size: 0.875rem;
 }
 
 .main {
   display: grid;
   grid-template-columns: 16rem auto;
-  gap: 1rem;
+  gap: var(--space-md);
   align-items: center;
-  margin: 1rem;
   max-width: 900px;
   margin: auto;
-  margin-top: 1rem;
+  margin-top: var(--space-md);
 }
 
 .mainGrid {
   height: 10rem;
-  padding: 0.5rem;
+  padding: var(--space-xs);
 }
 
 .selectOption {
   display: block;
-  padding: 0.5rem;
+  padding: var(--space-xs);
   width: 100%;
-  background-color: #2c2c2c;
-  margin: 0.5rem 0;
-  border-radius: 0.5rem;
+  background-color: var(--color-surface);
+  margin: var(--space-xs) 0;
+  border-radius: var(--radius-md);
   cursor: pointer;
 }
 
 .selectOption:hover {
-  background-color: #333;
+  background-color: var(--color-surface-hover);
 }
 
 .selectOptionTitle {
   display: flex;
-  gap: 0.5rem;
+  gap: var(--space-xs);
 }
 
 .selectOptionTitle :first-child {

--- a/src/ui/content/App.css
+++ b/src/ui/content/App.css
@@ -22,35 +22,66 @@
 
 .selectOption {
   display: block;
-  padding: var(--space-xs);
+  padding: var(--space-sm);
   width: 100%;
   background-color: var(--color-surface);
   margin: var(--space-xs) 0;
   border-radius: var(--radius-md);
+  border-left: 3px solid transparent;
   cursor: pointer;
+  text-align: left;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
 }
 
 .selectOption:hover {
   background-color: var(--color-surface-hover);
 }
 
-.selectOptionTitle {
+.selectOption.active.cpu { border-left-color: var(--color-cpu-stroke); }
+.selectOption.active.ram { border-left-color: var(--color-ram-stroke); }
+.selectOption.active.disk { border-left-color: var(--color-disk-stroke); }
+
+.selectOption.active {
+  background-color: var(--color-surface-hover);
+}
+
+.selectOptionHeader {
   display: flex;
-  gap: var(--space-xs);
+  justify-content: space-between;
+  align-items: baseline;
 }
 
-.selectOptionTitle :first-child {
-  font-weight: 600;
+.selectOptionLabel {
+  font-weight: 700;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--color-text-primary);
 }
 
-.selectOptionTitle :nth-child(2) {
-  font-weight: 400;
-  font-size: 0.8rem;
+.selectOptionUsage {
+  font-weight: 700;
+  font-size: 1.1rem;
+  font-variant-numeric: tabular-nums;
+}
+
+.selectOptionUsage.cpu { color: var(--color-cpu-stroke); }
+.selectOptionUsage.ram { color: var(--color-ram-stroke); }
+.selectOptionUsage.disk { color: var(--color-disk-stroke); }
+
+.selectOptionSubtitle {
+  font-size: 0.7rem;
+  color: var(--color-text-muted);
+  margin-top: 0.1rem;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .selectOptionChart {
-  height: 2rem;
+  height: 2.5rem;
   width: 100%;
+  margin-top: var(--space-xs);
 }
 
 .selectOptionChart * {

--- a/src/ui/content/App.tsx
+++ b/src/ui/content/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 import './App.css';
 import { useStatistics } from './useStatistics';
 import { Chart } from './Chart';
+import { SelectOption } from './SelectOption';
 
 function App() {
   const staticData = useStaticData();
@@ -54,6 +55,7 @@ function App() {
             view="CPU"
             subTitle={staticData?.cpuModel ?? ''}
             data={cpuUsages}
+            activeView={activeView}
           />
           <SelectOption
             onClick={() => setActiveView('RAM')}
@@ -61,6 +63,7 @@ function App() {
             view="RAM"
             subTitle={(staticData?.totalMemoryGB.toString() ?? '') + ' GB'}
             data={ramUsages}
+            activeView={activeView}
           />
           <SelectOption
             onClick={() => setActiveView('DISK')}
@@ -68,6 +71,7 @@ function App() {
             view="DISK"
             subTitle={(staticData?.totalStorage.toString() ?? '') + ' GB'}
             data={storageUsages}
+            activeView={activeView}
           />
         </div>
         <div className="mainGrid">
@@ -79,26 +83,6 @@ function App() {
         </div>
       </div>
     </div>
-  );
-}
-
-function SelectOption(props: {
-  title: string;
-  view: View;
-  subTitle: string;
-  data: number[];
-  onClick: () => void;
-}) {
-  return (
-    <button className="selectOption" onClick={props.onClick}>
-      <div className="selectOptionTitle">
-        <div>{props.title}</div>
-        <div>{props.subTitle}</div>
-      </div>
-      <div className="selectOptionChart">
-        <Chart selectedView={props.view} data={props.data} maxDataPoints={10} />
-      </div>
-    </button>
   );
 }
 

--- a/src/ui/content/SelectOption.tsx
+++ b/src/ui/content/SelectOption.tsx
@@ -1,0 +1,32 @@
+import { Chart } from './Chart';
+
+export function SelectOption(props: {
+  title: string;
+  view: View;
+  subTitle: string;
+  data: number[];
+  activeView: View;
+  onClick: () => void;
+}) {
+  const isActive = props.view === props.activeView;
+  const currentUsage = props.data.length > 0
+    ? Math.round(props.data[props.data.length - 1] * 100)
+    : 0;
+  const viewClass = props.view.toLowerCase();
+
+  return (
+    <button
+      className={`selectOption ${viewClass}${isActive ? ' active' : ''}`}
+      onClick={props.onClick}
+    >
+      <div className="selectOptionHeader">
+        <span className="selectOptionLabel">{props.title}</span>
+        <span className={`selectOptionUsage ${viewClass}`}>{currentUsage}%</span>
+      </div>
+      <div className="selectOptionSubtitle">{props.subTitle}</div>
+      <div className="selectOptionChart">
+        <Chart selectedView={props.view} data={props.data} maxDataPoints={10} />
+      </div>
+    </button>
+  );
+}

--- a/src/ui/index.css
+++ b/src/ui/index.css
@@ -1,12 +1,37 @@
 :root {
+  /* Background layers */
+  --color-bg: #242424;
+  --color-surface: #2c2c2c;
+  --color-surface-hover: #333333;
+
+  /* Text */
+  --color-text-primary: rgba(255, 255, 255, 0.87);
+  --color-text-muted: #888888;
+
+  /* Per-metric accent colors (kept in sync with Chart.tsx COLOR_MAP) */
+  --color-cpu-stroke: #5dd4ee;
+  --color-cpu-fill: #0a4d5c;
+  --color-ram-stroke: #e99311;
+  --color-ram-fill: #5f3c07;
+  --color-disk-stroke: #1acf4d;
+  --color-disk-fill: #0b5b22;
+
+  /* Spacing */
+  --space-xs: 0.5rem;
+  --space-sm: 0.75rem;
+  --space-md: 1rem;
+
+  /* Border radius */
+  --radius-md: 0.5rem;
+
   font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
   font-size: 16px;
   line-height: 24px;
   font-weight: 400;
 
   color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  color: var(--color-text-primary);
+  background-color: var(--color-bg);
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;


### PR DESCRIPTION
## Summary

Redesigns the metric selector cards to show live usage data and clear visual hierarchy. Cards now communicate at a glance which metric is active and what its current value is, rather than relying solely on the mini sparkline.

## Changes

- `SelectOption.tsx`: Extracted from `App.tsx` into its own file. Accepts `activeView` prop, computes current usage from latest data point, and applies per-metric CSS classes for accent coloring.
- `App.tsx`: Imports `SelectOption` from new file; passes `activeView` prop to each card.
- `App.css`: Replaces old flat card styles with new layout — left-border active indicator (per-metric accent color), usage % display, improved label typography (`0.75rem` uppercase), muted subtitle with ellipsis overflow, taller mini chart.

## Screenshots

| Before | After |
|--------|-------|
| Flat buttons, no active state, no usage % | Left accent border on active card, live usage % in metric color |

## Test Plan

- [ ] Each card shows the current usage as a percentage number
- [ ] Active card has a colored left border matching its metric (cyan/orange/green)
- [ ] Inactive cards are visually subdued
- [ ] Hover state is visible
- [ ] Clicking a card switches the active view
- [ ] Typecheck passes (pre-existing test-file TS errors are unrelated)
- [ ] Verify changes work in browser